### PR TITLE
bump up 1.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,7 +149,7 @@ dependencies = [
 
 [[package]]
 name = "gatekeeper"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "derive_more 0.99.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gatekeeper"
-version = "0.1.0"
+version = "1.0.0"
 repository = "https://github.com/Idein/gatekeeper"
 authors = ["takayuki goto <takayuki@idein.jp>"]
 edition = "2018"


### PR DESCRIPTION
`release 1.0.0`

## Improvements
- Gracefull shutdown
    - Wait for the accept thread shutdown. (#27)
    - Collect finished relay thread. (#30)
- Deploy docker image for any release tags. (#31)
