### PR TITLE
Rename: ipaddr prefix

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -128,7 +128,7 @@ Value of these fields are either `Any` or `Specif`.
       Specif:
         IpAddr:
           addr: 192.168.0.1
-          mask: 24
+          prefix: 24
     ```
 
     ```yaml
@@ -190,7 +190,7 @@ Value of these fields are either `Any` or `Specif`.
           Specif:
             IpAddr:
               addr: 192.168.0.1
-              mask: 16
+              prefix: 16
         port: Any
         protocol: Any
     ```

--- a/example.yml
+++ b/example.yml
@@ -12,7 +12,7 @@
       Specif:
         IpAddr:
           addr: 192.168.0.1
-          mask: 16
+          prefix: 16
     port: Any
     protocol: Any
 # allow some google domains using port 443

--- a/src/config.rs
+++ b/src/config.rs
@@ -68,7 +68,7 @@ impl ServerConfig {
     ///       Specif:
     ///         IpAddr:
     ///           addr: 192.168.0.1
-    ///           mask: 16
+    ///           prefix: 16
     ///     port: Any
     ///     protocol: Any
     /// "#.as_bytes())?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,13 +58,13 @@
 //! let mut rule = ConnectRule::none();
 //! // allow local ipv4 network 192.168.0.1/16
 //! rule.allow(
-//!     Specif(Pat::IpAddr { addr: "192.168.0.1".parse().unwrap(), mask: 16, }),
+//!     Specif(Pat::IpAddr { addr: "192.168.0.1".parse().unwrap(), prefix: 16, }),
 //!     Specif(80),
 //!     Any,
 //! );
 //! // allow local ipv4 network 192.168.0.1/16 port 443
 //! rule.allow(
-//!     Specif(Pat::IpAddr { addr: "192.168.0.1".parse().unwrap(), mask: 16, }),
+//!     Specif(Pat::IpAddr { addr: "192.168.0.1".parse().unwrap(), prefix: 16, }),
 //!     Specif(443),
 //!     Any,
 //! );

--- a/src/model/model.rs
+++ b/src/model/model.rs
@@ -488,7 +488,7 @@ impl ConnectRuleEntry {
 /// rule.allow(
 ///     Specif(Pat::IpAddr {
 ///         addr: "192.168.0.1".parse()?,
-///         mask: 16,
+///         prefix: 16,
 ///     }),
 ///     Specif(80),
 ///     Any,

--- a/src/model/model.rs
+++ b/src/model/model.rs
@@ -700,6 +700,29 @@ mod test {
     }
 
     #[test]
+    fn ipv6_pattern() {
+        use AddressPattern as Pat;
+        use RulePattern::*;
+        let mut rule = ConnectRule::none();
+        rule.allow(
+            Specif(Pat::IpAddr {
+                addr: "ff01::0".parse().unwrap(),
+                prefix: 32,
+            }),
+            Any,
+            Any,
+        );
+        assert!(rule.check(
+            SocketAddrV6::new(Ipv6Addr::new(0xff01, 0, 0, 0, 0, 0, 0, 0x1), 80, 0, 0).into(),
+            Tcp
+        ));
+        assert!(!rule.check(
+            SocketAddrV6::new(Ipv6Addr::new(0xffff, 0, 0, 0, 0, 0, 0, 0x1), 80, 0, 0).into(),
+            Tcp
+        ));
+    }
+
+    #[test]
     fn example_rule() {
         use std::fs::File;
         use std::path::Path;

--- a/src/model/model.rs
+++ b/src/model/model.rs
@@ -253,7 +253,7 @@ pub struct UdpDatagram<'a> {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum AddressPattern {
     /// e.g. 127.0.0.1/16
-    IpAddr { addr: IpAddr, mask: u8 },
+    IpAddr { addr: IpAddr, prefix: u8 },
     Domain {
         #[serde(with = "serde_regex")]
         pattern: Regex,
@@ -275,22 +275,22 @@ impl Matcher for AddressPattern {
             (
                 P::IpAddr {
                     addr: IpAddr::V4(addrp),
-                    mask,
+                    prefix,
                 },
                 Address::IpAddr(IpAddr::V4(addr), _),
             ) => {
-                let bmask = !0u32 << mask;
+                let bmask = !0u32 << prefix;
                 u32::from_be_bytes(addrp.octets()) & bmask
                     == u32::from_be_bytes(addr.octets()) & bmask
             }
             (
                 P::IpAddr {
                     addr: IpAddr::V6(addrp),
-                    mask,
+                    prefix,
                 },
                 Address::IpAddr(IpAddr::V6(addr), _),
             ) => {
-                let bmask = !0u128 << mask;
+                let bmask = !0u128 << prefix;
                 u128::from_be_bytes(addrp.octets()) & bmask
                     == u128::from_be_bytes(addr.octets()) & bmask
             }
@@ -637,7 +637,7 @@ mod test {
         rule.allow(
             Specif(Pat::IpAddr {
                 addr: "192.168.0.1".parse().unwrap(),
-                mask: 16,
+                prefix: 16,
             }),
             Specif(80),
             Any,
@@ -645,7 +645,7 @@ mod test {
         rule.allow(
             Specif(Pat::IpAddr {
                 addr: "192.168.0.1".parse().unwrap(),
-                mask: 16,
+                prefix: 16,
             }),
             Specif(443),
             Any,
@@ -667,7 +667,7 @@ mod test {
         rule.allow(
             Specif(Pat::IpAddr {
                 addr: "192.168.0.1".parse().unwrap(),
-                mask: 16,
+                prefix: 16,
             }),
             Specif(80),
             Any,
@@ -675,7 +675,7 @@ mod test {
         rule.allow(
             Specif(Pat::IpAddr {
                 addr: "192.168.0.1".parse().unwrap(),
-                mask: 16,
+                prefix: 16,
             }),
             Specif(443),
             Any,


### PR DESCRIPTION
Rename `mask` to `prefix`. (`mask` represents 0xFFF...00)
 Also, a bug in the IP address matching algorithm with a prefix length has been fixed.
