### PR TITLE
Use musle to reduce the size of the image for arm32v7 and fix the image for arm32v6

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,5 +1,5 @@
-[target.arm-unknown-linux-gnueabihf]
+[target.arm-unknown-linux-musleabihf]
 linker = "arm-linux-gnueabihf-gcc"
 
-[target.armv7-unknown-linux-gnueabihf]
+[target.armv7-unknown-linux-musleabihf]
 linker = "arm-linux-gnueabihf-gcc"

--- a/Dockerfile.arm32v6
+++ b/Dockerfile.arm32v6
@@ -2,16 +2,24 @@ FROM rust:1.40.0-slim-stretch AS builder
 
 WORKDIR /gatekeeper
 
-COPY . .
+COPY src            src
+COPY .cargo         .cargo
+COPY rust-toolchain .
+COPY Cargo.toml     .
+COPY Cargo.lock     .
+
+ENV CC_arm_unknown_linux_musleabihf arm-linux-gnueabihf-gcc
 
 # hadolint ignore=DL3015
 RUN apt-get update && \
     apt-get install -y --install-recommends gcc-arm-linux-gnueabihf=* && \
-    rustup target add arm-unknown-linux-gnueabihf && \
-    cargo build --target=arm-unknown-linux-gnueabihf --release && \
-    cp target/arm-unknown-linux-gnueabihf/release/gatekeeperd /
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* && \
+    rustup target add arm-unknown-linux-musleabihf && \
+    cargo build --target=arm-unknown-linux-musleabihf --release && \
+    cp target/arm-unknown-linux-musleabihf/release/gatekeeperd /
 
-FROM raspbian/stretch:041518
+FROM scratch
 
 COPY --from=builder /gatekeeperd /
 

--- a/Dockerfile.arm32v7
+++ b/Dockerfile.arm32v7
@@ -2,16 +2,24 @@ FROM rust:1.40.0-slim-stretch AS builder
 
 WORKDIR /gatekeeper
 
-COPY . .
+COPY src            src
+COPY .cargo         .cargo
+COPY rust-toolchain .
+COPY Cargo.toml     .
+COPY Cargo.lock     .
+
+ENV CC_armv7_unknown_linux_musleabihf arm-linux-gnueabihf-gcc
 
 # hadolint ignore=DL3015
 RUN apt-get update && \
     apt-get install -y --install-recommends gcc-arm-linux-gnueabihf=* && \
-    rustup target add armv7-unknown-linux-gnueabihf && \
-    cargo build --target=armv7-unknown-linux-gnueabihf --release && \
-    cp target/armv7-unknown-linux-gnueabihf/release/gatekeeperd /
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* && \
+    rustup target add armv7-unknown-linux-musleabihf && \
+    cargo build --target=armv7-unknown-linux-musleabihf --release && \
+    cp target/armv7-unknown-linux-musleabihf/release/gatekeeperd /
 
-FROM raspbian/stretch:041518
+FROM scratch
 
 COPY --from=builder /gatekeeperd /
 

--- a/Dockerfile.x86_64
+++ b/Dockerfile.x86_64
@@ -1,6 +1,10 @@
 FROM ekidd/rust-musl-builder:1.40.0 AS builder
 
-COPY . .
+COPY src            src
+COPY .cargo         .cargo
+COPY rust-toolchain .
+COPY Cargo.toml     .
+COPY Cargo.lock     .
 
 RUN cargo build --release && \
       strip /home/rust/src/target/x86_64-unknown-linux-musl/release/gatekeeperd


### PR DESCRIPTION
- Reduced the size of `:{version}-arm32v7` from 72.04MB to 1.88MB using `armv7-unknown-linux-musleabihf`.
- Make the image for `:{version}-arm32v6` work.
    - It wasn't working with pizero before the fix.
 