### PR TITLE
Support mDNS

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,5 +1,0 @@
-[target.arm-unknown-linux-musleabihf]
-linker = "arm-linux-gnueabihf-gcc"
-
-[target.armv7-unknown-linux-musleabihf]
-linker = "arm-linux-gnueabihf-gcc"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -172,7 +172,7 @@ workflows:
       - deploy-latest:
           matrix:
             parameters:
-              target: ["x86_64", "arm32v6", "arm32v7"]
+              target: ["x86_64"]
           filters:
             branches:
               only: master
@@ -182,7 +182,7 @@ workflows:
       - deploy-tags:
           matrix:
             parameters:
-              target: ["x86_64", "arm32v6", "arm32v7"]
+              target: ["x86_64"]
           filters:
             tags:
               only: /^v.*/

--- a/Dockerfile.arm32v6
+++ b/Dockerfile.arm32v6
@@ -1,6 +1,8 @@
 # hadolint ignore=DL3007
 FROM balenalib/rpi-raspbian:latest AS builder
 
+ENV HOME /root/
+
 WORKDIR /gatekeeper
 
 COPY src            src
@@ -8,18 +10,15 @@ COPY rust-toolchain .
 COPY Cargo.toml     .
 COPY Cargo.lock     .
 
-# https://raw.githubusercontent.com/Idein/gatekeeper/master/rust-toolchain
-ENV RUST_VERSION "1.40.0"
+RUN update-ca-certificates -f && \
+    curl -sSfL https://sh.rustup.rs > rustup.sh && \
+    sh rustup.sh -y \
+      --default-toolchain "$(cat rust-toolchain)-arm-unknown-linux-gnueabihf" \
+      --profile minimal \
+      --target arm-unknown-linux-gnueabihf && \
+    rm -f rustup.sh
 
-ENV RUST_SOURCE_BASENAME "rust-${RUST_VERSION}-arm-unknown-linux-gnueabihf"
-ENV RUST_SOURCE_ARCHIVE_NAME "${RUST_SOURCE_BASENAME}.tar.gz"
-ENV RUST_SOURCE_URL "https://static.rust-lang.org/dist/${RUST_SOURCE_ARCHIVE_NAME}"
-
-RUN curl --insecure -O ${RUST_SOURCE_URL} && \
-    tar xvzf ${RUST_SOURCE_ARCHIVE_NAME} && \
-    rm -f ${RUST_SOURCE_ARCHIVE_NAME} && \
-    ./${RUST_SOURCE_BASENAME}/install.sh && \
-    rm -rf ${RUST_SOURCE_BASENAME}
+ENV PATH $HOME/.cargo/bin:$PATH
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends build-essential=* && \

--- a/Dockerfile.arm32v6
+++ b/Dockerfile.arm32v6
@@ -1,31 +1,54 @@
-FROM rust:1.40.0-slim-stretch AS builder
+# hadolint ignore=DL3007
+FROM balenalib/rpi-raspbian:latest AS builder
 
 WORKDIR /gatekeeper
 
 COPY src            src
-COPY .cargo         .cargo
 COPY rust-toolchain .
 COPY Cargo.toml     .
 COPY Cargo.lock     .
 
-ENV CC_arm_unknown_linux_musleabihf arm-linux-gnueabihf-gcc
-ENV RUSTFLAGS "-Clinker=arm-linux-gnueabihf-gcc"
+# https://raw.githubusercontent.com/Idein/gatekeeper/master/rust-toolchain
+ENV RUST_VERSION "1.40.0"
 
-# hadolint ignore=DL3015
+ENV RUST_SOURCE_BASENAME "rust-${RUST_VERSION}-arm-unknown-linux-gnueabihf"
+ENV RUST_SOURCE_ARCHIVE_NAME "${RUST_SOURCE_BASENAME}.tar.gz"
+ENV RUST_SOURCE_URL "https://static.rust-lang.org/dist/${RUST_SOURCE_ARCHIVE_NAME}"
+
+RUN curl --insecure -O ${RUST_SOURCE_URL} && \
+    tar xvzf ${RUST_SOURCE_ARCHIVE_NAME} && \
+    rm -f ${RUST_SOURCE_ARCHIVE_NAME} && \
+    ./${RUST_SOURCE_BASENAME}/install.sh && \
+    rm -rf ${RUST_SOURCE_BASENAME}
+
 RUN apt-get update && \
-    apt-get install -y --install-recommends gcc-arm-linux-gnueabihf=* && \
+    apt-get install -y --no-install-recommends build-essential=* && \
     apt-get clean && \
-    rm -rf /var/lib/apt/lists/* && \
-    rustup target add arm-unknown-linux-musleabihf && \
-    cargo build --target=arm-unknown-linux-musleabihf --release && \
-    cp target/arm-unknown-linux-musleabihf/release/gatekeeperd /
+    rm -rf /var/lib/apt/lists/*
 
-FROM scratch
+ENV RUSTFLAGS "-Clinker=arm-linux-gnueabihf-gcc -Ccodegen_units=1"
+
+RUN cargo build --release && \
+    cp target/release/gatekeeperd /
+
+# hadolint ignore=DL3007
+FROM balenalib/rpi-raspbian:latest AS runner
 
 COPY --from=builder /gatekeeperd /
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends avahi-daemon=* dbus=* libnss-mdns=* && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 EXPOSE 1080
 
 ENV RUST_LOG gatekeeper=info
 
-ENTRYPOINT ["/gatekeeperd"]
+RUN printf '#!/bin/bash\n\
+/etc/init.d/dbus start\n\
+/etc/init.d/avahi-daemon start\n\
+/gatekeeperd $*\n\
+' > /entrypoint.sh && chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile.arm32v6
+++ b/Dockerfile.arm32v6
@@ -25,7 +25,7 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-ENV RUSTFLAGS "-Clinker=arm-linux-gnueabihf-gcc -Ccodegen_units=1"
+ENV RUSTFLAGS "-Clinker=arm-linux-gnueabihf-gcc"
 
 RUN cargo build --release && \
     cp target/release/gatekeeperd /

--- a/Dockerfile.arm32v6
+++ b/Dockerfile.arm32v6
@@ -45,10 +45,6 @@ EXPOSE 1080
 
 ENV RUST_LOG gatekeeper=info
 
-RUN printf '#!/bin/bash\n\
-/etc/init.d/dbus start\n\
-/etc/init.d/avahi-daemon start\n\
-/gatekeeperd $*\n\
-' > /entrypoint.sh && chmod +x /entrypoint.sh
+COPY entrypoint.sh /
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile.arm32v6
+++ b/Dockerfile.arm32v6
@@ -9,6 +9,7 @@ COPY Cargo.toml     .
 COPY Cargo.lock     .
 
 ENV CC_arm_unknown_linux_musleabihf arm-linux-gnueabihf-gcc
+ENV RUSTFLAGS "-Clinker=arm-linux-gnueabihf-gcc"
 
 # hadolint ignore=DL3015
 RUN apt-get update && \

--- a/Dockerfile.arm32v7
+++ b/Dockerfile.arm32v7
@@ -9,6 +9,7 @@ COPY Cargo.toml     .
 COPY Cargo.lock     .
 
 ENV CC_armv7_unknown_linux_musleabihf arm-linux-gnueabihf-gcc
+ENV RUSTFLAGS "-Clinker=arm-linux-gnueabihf-gcc"
 
 # hadolint ignore=DL3015
 RUN apt-get update && \

--- a/Dockerfile.arm32v7
+++ b/Dockerfile.arm32v7
@@ -45,10 +45,6 @@ EXPOSE 1080
 
 ENV RUST_LOG gatekeeper=info
 
-RUN printf '#!/bin/bash\n\
-/etc/init.d/dbus start\n\
-/etc/init.d/avahi-daemon start\n\
-/gatekeeperd $*\n\
-' > /entrypoint.sh && chmod +x /entrypoint.sh
+COPY entrypoint.sh /
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile.arm32v7
+++ b/Dockerfile.arm32v7
@@ -1,6 +1,8 @@
 # hadolint ignore=DL3007
 FROM balenalib/rpi-raspbian:latest AS builder
 
+ENV HOME /root/
+
 WORKDIR /gatekeeper
 
 COPY src            src
@@ -8,18 +10,15 @@ COPY rust-toolchain .
 COPY Cargo.toml     .
 COPY Cargo.lock     .
 
-# https://raw.githubusercontent.com/Idein/gatekeeper/master/rust-toolchain
-ENV RUST_VERSION "1.40.0"
+RUN update-ca-certificates -f && \
+    curl -sSfL https://sh.rustup.rs > rustup.sh && \
+    sh rustup.sh -y \
+      --default-toolchain "$(cat rust-toolchain)-armv7-unknown-linux-gnueabihf" \
+      --profile minimal \
+      --target armv7-unknown-linux-gnueabihf && \
+    rm -f rustup.sh
 
-ENV RUST_SOURCE_BASENAME "rust-${RUST_VERSION}-armv7-unknown-linux-gnueabihf"
-ENV RUST_SOURCE_ARCHIVE_NAME "${RUST_SOURCE_BASENAME}.tar.gz"
-ENV RUST_SOURCE_URL "https://static.rust-lang.org/dist/${RUST_SOURCE_ARCHIVE_NAME}"
-
-RUN curl --insecure -O ${RUST_SOURCE_URL} && \
-    tar xvzf ${RUST_SOURCE_ARCHIVE_NAME} && \
-    rm -f ${RUST_SOURCE_ARCHIVE_NAME} && \
-    ./${RUST_SOURCE_BASENAME}/install.sh && \
-    rm -rf ${RUST_SOURCE_BASENAME}
+ENV PATH $HOME/.cargo/bin:$PATH
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends build-essential=* && \

--- a/Dockerfile.arm32v7
+++ b/Dockerfile.arm32v7
@@ -1,31 +1,54 @@
-FROM rust:1.40.0-slim-stretch AS builder
+# hadolint ignore=DL3007
+FROM balenalib/rpi-raspbian:latest AS builder
 
 WORKDIR /gatekeeper
 
 COPY src            src
-COPY .cargo         .cargo
 COPY rust-toolchain .
 COPY Cargo.toml     .
 COPY Cargo.lock     .
 
-ENV CC_armv7_unknown_linux_musleabihf arm-linux-gnueabihf-gcc
+# https://raw.githubusercontent.com/Idein/gatekeeper/master/rust-toolchain
+ENV RUST_VERSION "1.40.0"
+
+ENV RUST_SOURCE_BASENAME "rust-${RUST_VERSION}-armv7-unknown-linux-gnueabihf"
+ENV RUST_SOURCE_ARCHIVE_NAME "${RUST_SOURCE_BASENAME}.tar.gz"
+ENV RUST_SOURCE_URL "https://static.rust-lang.org/dist/${RUST_SOURCE_ARCHIVE_NAME}"
+
+RUN curl --insecure -O ${RUST_SOURCE_URL} && \
+    tar xvzf ${RUST_SOURCE_ARCHIVE_NAME} && \
+    rm -f ${RUST_SOURCE_ARCHIVE_NAME} && \
+    ./${RUST_SOURCE_BASENAME}/install.sh && \
+    rm -rf ${RUST_SOURCE_BASENAME}
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends build-essential=* && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
 ENV RUSTFLAGS "-Clinker=arm-linux-gnueabihf-gcc"
 
-# hadolint ignore=DL3015
-RUN apt-get update && \
-    apt-get install -y --install-recommends gcc-arm-linux-gnueabihf=* && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/* && \
-    rustup target add armv7-unknown-linux-musleabihf && \
-    cargo build --target=armv7-unknown-linux-musleabihf --release && \
-    cp target/armv7-unknown-linux-musleabihf/release/gatekeeperd /
+RUN cargo build --release && \
+    cp target/release/gatekeeperd /
 
-FROM scratch
+# hadolint ignore=DL3007
+FROM balenalib/rpi-raspbian:latest AS runner
 
 COPY --from=builder /gatekeeperd /
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends avahi-daemon=* dbus=* libnss-mdns=* && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 EXPOSE 1080
 
 ENV RUST_LOG gatekeeper=info
 
-ENTRYPOINT ["/gatekeeperd"]
+RUN printf '#!/bin/bash\n\
+/etc/init.d/dbus start\n\
+/etc/init.d/avahi-daemon start\n\
+/gatekeeperd $*\n\
+' > /entrypoint.sh && chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile.x86_64
+++ b/Dockerfile.x86_64
@@ -1,7 +1,6 @@
 FROM ekidd/rust-musl-builder:1.40.0 AS builder
 
 COPY src            src
-COPY .cargo         .cargo
 COPY rust-toolchain .
 COPY Cargo.toml     .
 COPY Cargo.lock     .

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+/etc/init.d/dbus start
+/etc/init.d/avahi-daemon start
+/gatekeeperd $*


### PR DESCRIPTION
mDNS support is added in build for arm32v6 and arm32v7.

- The size of the image has been increased from 1MB to 70MB.
- arm32v6 and arm32v7 are excluded because they cannot be built by CI (as far as I know now).