### PR TITLE
Changed listen(2)'s backlog parameter from 0 to 256 to surely accept connection from clients

### DIFF
--- a/src/acceptor.rs
+++ b/src/acceptor.rs
@@ -124,8 +124,14 @@ impl Binder for TcpBinder {
             .reuse_address(true)?
             .bind(&addr)
             .map_err(|err| addr_error(err, addr))?;
+
+        // `backlog` parameter to `TcpBuilder::listen() is directly passed to `listen(2)` system call.
+        // If it is too small, clients may not `connect(2)` to the server.
+        // Here, `backlog` is intended to be as large as `net.core.somaxconn` kernel parameter,
+        let listener = tcp.listen(256)?;
+
         Ok(TcpAcceptor::new(
-            tcp.listen(0)?,
+            listener,
             self.rw_timeout,
             self.rx.clone(),
             self.accept_timeout,


### PR DESCRIPTION
## Problem

On an aarch64-unknown-linux-gnu platform, `gatekeeperd` could not accept any connection from a client.

```bash
gatekeeperd
```

```bash
telnet localhost 1080  # just blocks for a while
```

This PR solves it.


## Discussion

Although `backlog = 1` solves the above issue, it is not enought to accept parallel connections from this program:

```rust
fn main() {
    use std::net::TcpStream;
    use std::thread;
    let mut handlers = Vec::new();
    for _ in 0..100 {
        let h = thread::spawn(|| {
            TcpStream::connect("localhost:1080").unwrap();
        });
        handlers.push(h);
    }
    for h in handlers {
        h.join().unwrap();
    }
}
```

Some threads succeed to establish connection but others get panic'ed after about 120sec later.

```rust
thread '<unnamed>' panicked at 'called `Result::unwrap()` on an `Err` value: Os { code: 110, kind: TimedOut, message: "Connection timed out" }', src/main.rs:9:13
```

I would like to make backlog size large enough to accept many parallel connections.
The trade-off should be memory footprint but TCP listen queue size maybe small at first and grows with the number of connections.
Also, internal [TCP listen queue size is capped by `net.core.somaxconn` kernel parameter](https://www.man7.org/linux/man-pages/man2/listen.2.html).
So I made `backlog = 256`, while some Linux platforms I checked have 128 in `/proc/sys/net/core/somaxconn`.