### PR TITLE
bump up v2.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,7 +149,7 @@ dependencies = [
 
 [[package]]
 name = "gatekeeper"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "derive_more 0.99.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gatekeeper"
-version = "2.0.0"
+version = "2.1.0"
 repository = "https://github.com/Idein/gatekeeper"
 authors = ["takayuki goto <takayuki@idein.jp>"]
 edition = "2018"


### PR DESCRIPTION
`release 2.1.0`

## Improvements
- Enlarge listen queue size from 0 to 256 (#41)