### PR TITLE
Support wildcard

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -20,7 +20,7 @@ Gatekeeper allow users to restricting connection based on:
 
 - target address
     - ip address (subnet range)
-    - domain name (regex matching)
+    - domain name (regex matching, wildcard)
 - port number
 - protocol (currently, tcp is only supported)
 
@@ -120,7 +120,8 @@ Value of these fields are either `Any` or `Specif`.
     address: Any
     ```
 
-  `address` is either `IpAddr` or `Domain`.
+  `address` is either `IpAddr` or `Domain`.  
+  `IpAddr` is specified with `addr` and `prefix`.
 
     ```yaml
     # 192.168.0.1/24
@@ -131,6 +132,8 @@ Value of these fields are either `Any` or `Specif`.
           prefix: 24
     ```
 
+  `Domain` is specified as either `pattern` or `wildcard`.
+
     ```yaml
     # {mail.,}google.{com,co.jp}
     address:
@@ -140,6 +143,14 @@ Value of these fields are either `Any` or `Specif`.
           pattern: '\A(mail\.)?google.((com|co)\.jp)\z'
     ```
 
+    ```yaml
+    # allow any Amazon API Gateway's REST API
+    address:
+      Specif:
+        Domain:
+          # converted to the regex pattern: \A[A-Za-z0-9-]{1,63}\.execute\-api\.[A-Za-z0-9-]{1,63}\.amazonaws\.com\z
+          wildcard: '*.execute-api.*.amazonaws.com'
+    ```
 
 - `port`
 

--- a/example.yml
+++ b/example.yml
@@ -27,12 +27,12 @@
       Specif: 443
     protocol:
       Specif: Tcp
-# allow subdomains of rust-lang.org
+# allow any Amazon API Gateway's REST API
 - Allow:
     address:
       Specif:
         Domain:
-          wildcard: '*.rust-lang.org'
+          wildcard: '*.execute-api.*.amazonaws.com'
     port:
       Specif: 443
     protocol:

--- a/example.yml
+++ b/example.yml
@@ -27,6 +27,16 @@
       Specif: 443
     protocol:
       Specif: Tcp
+# allow subdomains of rust-lang.org
+- Allow:
+    address:
+      Specif:
+        Domain:
+          wildcard: '*.rust-lang.org'
+    port:
+      Specif: 443
+    protocol:
+      Specif: Tcp
 # deny facebook.com
 - Deny:
     address:

--- a/src/model/model.rs
+++ b/src/model/model.rs
@@ -925,7 +925,7 @@ mod test {
             Specif(L4Protocol::Tcp),
         );
         rule.allow(
-            Specif(AddressPattern::Domain(DomainPattern::Wildcard {
+            Specif(Pat::Domain(DomainPattern::Wildcard {
                 wildcard: "*.actcast.io".to_owned(),
             })),
             Any,

--- a/src/model/model.rs
+++ b/src/model/model.rs
@@ -370,8 +370,8 @@ impl Matcher for AddressPattern {
                 let bmask = !0u128 << (128 - prefix);
                 u128::from(*addrp) & bmask == u128::from(*addr) & bmask
             }
-            (P::Domain(DomainPattern::Regex { pattern: reg }), Address::Domain(domain, _)) => {
-                reg.is_match(domain)
+            (P::Domain(DomainPattern::Regex { pattern }), Address::Domain(domain, _)) => {
+                pattern.is_match(domain)
             }
             (P::Domain(DomainPattern::Wildcard { wildcard: s }), Address::Domain(domain, _)) => {
                 let pattern = format!(
@@ -565,10 +565,8 @@ mod format {
                 IpAddr { addr, prefix } => AddressPattern::addr(addr, prefix).map_err(|err| {
                     de::Error::invalid_value(Unexpected::Unsigned(prefix as u64), &err)
                 }),
-                Domain(DomainPatternDef::Regex { pattern: reg }) => {
-                    Ok(AddressPattern::Domain(DomainPattern::Regex {
-                        pattern: reg,
-                    }))
+                Domain(DomainPatternDef::Regex { pattern }) => {
+                    Ok(AddressPattern::Domain(DomainPattern::Regex { pattern }))
                 }
                 Domain(DomainPatternDef::Wildcard { wildcard: s }) => {
                     Ok(AddressPattern::Domain(DomainPattern::Wildcard {

--- a/src/model/model.rs
+++ b/src/model/model.rs
@@ -373,10 +373,10 @@ impl Matcher for AddressPattern {
             (P::Domain(DomainPattern::Regex { pattern }), Address::Domain(domain, _)) => {
                 pattern.is_match(domain)
             }
-            (P::Domain(DomainPattern::Wildcard { wildcard: s }), Address::Domain(domain, _)) => {
+            (P::Domain(DomainPattern::Wildcard { wildcard }), Address::Domain(domain, _)) => {
                 let pattern = format!(
                     r"\A{}\z",
-                    &escape(s).replace(WILDCARD_AFTER_ESCAPE, WILDCARD_REPLACEMENT)
+                    &escape(wildcard).replace(WILDCARD_AFTER_ESCAPE, WILDCARD_REPLACEMENT)
                 );
                 let reg = Regex::new(&pattern).unwrap();
                 reg.is_match(domain)
@@ -568,10 +568,8 @@ mod format {
                 Domain(DomainPatternDef::Regex { pattern }) => {
                     Ok(AddressPattern::Domain(DomainPattern::Regex { pattern }))
                 }
-                Domain(DomainPatternDef::Wildcard { wildcard: s }) => {
-                    Ok(AddressPattern::Domain(DomainPattern::Wildcard {
-                        wildcard: s,
-                    }))
+                Domain(DomainPatternDef::Wildcard { wildcard }) => {
+                    Ok(AddressPattern::Domain(DomainPattern::Wildcard { wildcard }))
                 }
             }
         }

--- a/src/model/model.rs
+++ b/src/model/model.rs
@@ -376,11 +376,9 @@ impl Matcher for AddressPattern {
                 pattern.is_match(domain)
             }
             (P::Domain(DP::Wildcard { wildcard }), Address::Domain(domain, _)) => {
-                let wildcard_after_escape = r"\*";
                 let pattern = format!(
                     r"\A{}\z",
-                    &escape(wildcard)
-                        .replace(wildcard_after_escape, AVAILABLE_STRINGS_FOR_DOMAIN_LABEL)
+                    &escape(wildcard).replace(r"\*", AVAILABLE_STRINGS_FOR_DOMAIN_LABEL)
                 );
                 let reg = Regex::new(&pattern).unwrap();
                 reg.is_match(domain)

--- a/src/model/model.rs
+++ b/src/model/model.rs
@@ -350,6 +350,7 @@ impl Matcher for AddressPattern {
 
     fn r#match(&self, addr: &Self::Item) -> bool {
         use AddressPattern as P;
+        use DomainPattern as DP;
         match (self, addr) {
             (
                 P::IpAddr {
@@ -371,10 +372,10 @@ impl Matcher for AddressPattern {
                 let bmask = !0u128 << (128 - prefix);
                 u128::from(*addrp) & bmask == u128::from(*addr) & bmask
             }
-            (P::Domain(DomainPattern::Regex { pattern }), Address::Domain(domain, _)) => {
+            (P::Domain(DP::Regex { pattern }), Address::Domain(domain, _)) => {
                 pattern.is_match(domain)
             }
-            (P::Domain(DomainPattern::Wildcard { wildcard }), Address::Domain(domain, _)) => {
+            (P::Domain(DP::Wildcard { wildcard }), Address::Domain(domain, _)) => {
                 let wildcard_after_escape = r"\*";
                 let pattern = format!(
                     r"\A{}\z",

--- a/src/model/model.rs
+++ b/src/model/model.rs
@@ -801,15 +801,15 @@ mod test {
         use RulePattern::*;
         struct Case {
             wildcard: String,
-            valid_domains: Vec<String>,
-            invalid_domains: Vec<String>,
+            match_domains: Vec<String>,
+            unmatch_domains: Vec<String>,
         }
         impl Case {
-            fn new(wildcard: &str, valid_domains: Vec<&str>, invalid_domains: Vec<&str>) -> Self {
+            fn new(wildcard: &str, match_domains: Vec<&str>, unmatch_domains: Vec<&str>) -> Self {
                 Case {
                     wildcard: wildcard.to_owned(),
-                    valid_domains: valid_domains.into_iter().map(|s| s.to_owned()).collect(),
-                    invalid_domains: invalid_domains.into_iter().map(|s| s.to_owned()).collect(),
+                    match_domains: match_domains.into_iter().map(|s| s.to_owned()).collect(),
+                    unmatch_domains: unmatch_domains.into_iter().map(|s| s.to_owned()).collect(),
                 }
             }
         }
@@ -849,10 +849,10 @@ mod test {
                 Specif(443),
                 Specif(Tcp),
             );
-            for domain in case.valid_domains {
+            for domain in case.match_domains {
                 assert!(rule.check(Domain(domain, 443), Tcp))
             }
-            for domain in case.invalid_domains {
+            for domain in case.unmatch_domains {
                 assert!(!rule.check(Domain(domain, 443), Tcp))
             }
         }

--- a/src/model/model.rs
+++ b/src/model/model.rs
@@ -43,7 +43,10 @@ use serde::*;
 pub const DEFAULT_PROTOCOL_VERSION: ProtocolVersion = ProtocolVersion(5);
 
 const WILDCARD_AFTER_ESCAPE: &'static str = r"\*";
-const WILDCARD_REPLACEMENT: &'static str = r"[a-zA-Z0-9-]{1,63}";
+
+// Domain labels can include letter, digit and hyphen
+// See https://tools.ietf.org/html/rfc1035#section-2.3.1
+const AVAILABLE_STRINGS_FOR_DOMAIN_LABEL: &'static str = r"[A-Za-z0-9-]{1,63}";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Into, From, Display)]
 pub struct ProtocolVersion(u8);
@@ -376,7 +379,8 @@ impl Matcher for AddressPattern {
             (P::Domain(DomainPattern::Wildcard { wildcard }), Address::Domain(domain, _)) => {
                 let pattern = format!(
                     r"\A{}\z",
-                    &escape(wildcard).replace(WILDCARD_AFTER_ESCAPE, WILDCARD_REPLACEMENT)
+                    &escape(wildcard)
+                        .replace(WILDCARD_AFTER_ESCAPE, AVAILABLE_STRINGS_FOR_DOMAIN_LABEL)
                 );
                 let reg = Regex::new(&pattern).unwrap();
                 reg.is_match(domain)

--- a/src/model/model.rs
+++ b/src/model/model.rs
@@ -565,14 +565,15 @@ mod format {
         {
             // impl Deserialize for AddressPattern using the Deserialize for AddressPatternDef
             use AddressPatternDef::*;
+            use DomainPatternDef::*;
             match AddressPatternDef::deserialize(deserializer)? {
                 IpAddr { addr, prefix } => AddressPattern::addr(addr, prefix).map_err(|err| {
                     de::Error::invalid_value(Unexpected::Unsigned(prefix as u64), &err)
                 }),
-                Domain(DomainPatternDef::Regex { pattern }) => {
+                Domain(Regex { pattern }) => {
                     Ok(AddressPattern::Domain(DomainPattern::Regex { pattern }))
                 }
-                Domain(DomainPatternDef::Wildcard { wildcard }) => {
+                Domain(Wildcard { wildcard }) => {
                     Ok(AddressPattern::Domain(DomainPattern::Wildcard { wildcard }))
                 }
             }

--- a/src/model/model.rs
+++ b/src/model/model.rs
@@ -42,8 +42,6 @@ use serde::*;
 
 pub const DEFAULT_PROTOCOL_VERSION: ProtocolVersion = ProtocolVersion(5);
 
-const WILDCARD_AFTER_ESCAPE: &'static str = r"\*";
-
 // Domain labels can include letter, digit and hyphen
 // See https://tools.ietf.org/html/rfc1035#section-2.3.1
 const AVAILABLE_STRINGS_FOR_DOMAIN_LABEL: &'static str = r"[A-Za-z0-9-]{1,63}";
@@ -377,10 +375,11 @@ impl Matcher for AddressPattern {
                 pattern.is_match(domain)
             }
             (P::Domain(DomainPattern::Wildcard { wildcard }), Address::Domain(domain, _)) => {
+                let wildcard_after_escape = r"\*";
                 let pattern = format!(
                     r"\A{}\z",
                     &escape(wildcard)
-                        .replace(WILDCARD_AFTER_ESCAPE, AVAILABLE_STRINGS_FOR_DOMAIN_LABEL)
+                        .replace(wildcard_after_escape, AVAILABLE_STRINGS_FOR_DOMAIN_LABEL)
                 );
                 let reg = Regex::new(&pattern).unwrap();
                 reg.is_match(domain)


### PR DESCRIPTION
Added a `wildcard` field to the `Domain`  to specify a domain like `*.execute-api.*.amazonaws.com`.