### PR TITLE
Update CI env

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,14 +65,14 @@ jobs:
           CARGO_HOME: /home/circleci/.cargo
           GIT_AUTHOR_NAME: circleci
           GIT_AUTHOR_EMAIL: circleci@example.com
+          GIT_COMMITTER_NAME: circleci
+          GIT_COMMITTER_EMAIL: circleci@example.com
     working_directory: /tmp/gatekeeper
     steps:
       - checkout
       - run:
           name: Merge origin/master
           command: |
-            git config --global user.email "circleci@example.com"
-            git config --global user.name "circleci"
             git merge --no-edit origin/master
       - run:
           name: Environment Setup
@@ -102,14 +102,14 @@ jobs:
       RUST_BACKTRACE: 1
       GIT_AUTHOR_NAME: circleci
       GIT_AUTHOR_EMAIL: circleci@example.com
+      GIT_COMMITTER_NAME: circleci
+      GIT_COMMITTER_EMAIL: circleci@example.com
     working_directory: /tmp/gatekeeper
     steps:
       - checkout
       - run:
           name: Merge origin/master
           command: |
-            git config --global user.email "circleci@example.com"
-            git config --global user.name "circleci"
             git merge --no-edit origin/master
       - run: cat rust-toolchain >> /tmp/rustup
       - install-rustup

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,7 +59,7 @@ commands:
 jobs:
   build:
     docker:
-      - image: circleci/rust:1.50.0-buster
+      - image: cimg/rust:1.50.0
         environment:
           RUST_BACKTRACE: 1
           CARGO_HOME: /home/circleci/.cargo
@@ -97,7 +97,7 @@ jobs:
 
   integration_test:
     machine:
-      image: circleci/classic:201808-01
+      image: ubuntu-2004:202201-02
     environment:
       RUST_BACKTRACE: 1
       GIT_AUTHOR_NAME: circleci


### PR DESCRIPTION
Now [CI is failing](https://app.circleci.com/pipelines/github/Idein/gatekeeper/168/workflows/2787303d-e631-462e-ab0c-d10a290e0cd7/jobs/374) with:
-  `You’re using a deprecated Docker convenience image. Upgrade to a next-gen Docker convenience image.` and
-  `This job was rejected because the image is unavailable`.

Update docker images used for CI jobs.